### PR TITLE
Add make install

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -52,7 +52,7 @@ corange.res: corange.rc
 	windres $< -O coff -o $@
 	
 clean:
-	rm $(OBJ) $(STATIC) $(DYNAMIC)
+	$(RM) $(OBJ) $(STATIC) $(DYNAMIC)
   
 install_unix: $(STATIC)
 	cp $(STATIC) /usr/local/lib/$(STATIC)

--- a/Makefile
+++ b/Makefile
@@ -63,3 +63,14 @@ install_win32: $(STATIC)
 install_win64: $(STATIC) $(DYNAMIC)
 	cp $(STATIC) C:/MinGW64/x86_64-w64-mingw32/lib/$(STATIC)
 	cp $(DYNAMIC) C:/MinGW64/x86_64-w64-mingw32/bin/$(DYNAMIC)
+
+ifeq ($(findstring MINGW,$(PLATFORM)),MINGW)
+ifndef PROGRAMFILES(x86)
+install: install_win32
+else
+install: install_win64
+endif
+
+else
+install: install_unix
+endif


### PR DESCRIPTION
This PR adds the install target to the base Makefile. It performs installation specific to the OS that it is built on.